### PR TITLE
ci: convert some workflows to actions

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -25,6 +25,7 @@ jobs:
     name: Update dependencies
     runs-on: ubuntu-latest
     steps:
+      - run: printf '::notice::The dependencies workflow is deprecated. Use the update action instead.\n'
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,3 @@ jobs:
         run: npm install
       - name: Run ESLint
         run: npm run lint
-  # TODO: add clang-{tidy,format}?

--- a/actions/test/action.yml
+++ b/actions/test/action.yml
@@ -1,0 +1,39 @@
+name: Tree-sitter test action
+description: Run tree-sitter tests
+
+inputs:
+  lint:
+    description: Lint
+    default: 'false'
+  generate:
+    description: Verify generated parser
+    default: 'false'
+  test-grammar:
+    description: Test the grammar
+    default: 'true'
+  test-library:
+    description: Test the rust library
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Lint
+      if: inputs.lint == 'true'
+      shell: sh
+      run: npm run lint
+    - name: Verify generated parser
+      if: inputs.generate == 'true'
+      continue-on-error: true
+      shell: sh
+      run: |-
+        tree-sitter generate --no-bindings
+        git diff --exit-code -- src/parser.c
+    - name: Run grammar tests
+      if: inputs.test-grammar == 'true'
+      shell: sh
+      run: npm test
+    - name: Run library tests
+      if: inputs.test-library == 'true'
+      shell: sh
+      run: cargo test

--- a/actions/update/action.yml
+++ b/actions/update/action.yml
@@ -1,0 +1,68 @@
+name: Tree-sitter update action
+description: Update tree-sitter parser dependencies
+
+inputs:
+  parent-name:
+    description: The parent language name (for scanner updates)
+  language-name:
+    description: The current language name (for scanner updates)
+  pr-branch:
+    description: The name of the PR branch
+    default: update-parser-pr
+  jq-script:
+    description: The jq script that generates the PR body
+    default: |-
+      .packages | to_entries | del(.[0])[] |
+        "- [`\(.key[13:])@\(.value.version)`]" +
+        "(https://www.npmjs.com/package/\(.key[13:])/v/\(.value.version))"
+
+runs:
+  using: composite
+  steps:
+    - name: Update dependencies
+      shell: sh
+      run: npm update
+    - name: Update scanner
+      if: inputs.parent-name != ''
+      shell: sh
+      run: |-
+        sed 'node_modules/tree-sitter-${{inputs.parent-name}}/src/scanner.c' \
+          -e 's/${{inputs.parent-name}}/${{inputs.language-name}}/g' > src/scanner.c
+        changes="$(git diff --exit-code -- src/scanner.c)"
+        if (($? -eq 1)); then
+          printf '## Scanner changes\n\n```diff\n%s\n```\n' "$changes" >> "$GITHUB_SUMMARY"
+        fi
+    - name: Install dependencies
+      shell: sh
+      run: npm install
+    - name: Generate parser
+      shell: sh
+      run: node_modules/.bin/tree-sitter generate --no-bindings
+    - name: Run tests
+      shell: sh
+      run: npm test
+    - name: Check package versions
+      id: versions
+      shell: sh
+      run: |-
+        packages="$(jq -r '${{inputs.jq-script}}' package-lock.json)"
+        printf '\n## Package versions\n\n%s\n' "$packages" >> "$GITHUB_SUMMARY"
+        printf 'pr_body<<EOF\n%s\nEOF\n' >> "$GITHUB_OUTPUT" "$packages"
+    - name: Commit changes
+      id: auto_commit
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: "chore(deps): update & regenerate parser"
+        commit_author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+        branch: ${{inputs.pr-branch}}
+        create_branch: true
+        skip_checkout: true
+        skip_fetch: true
+    - name: Create pull request
+      uses: peter-evans/create-pull-request@v5
+      if: steps.outputs.auto_commit.changes_detected == 'true'
+      with:
+        title: "chore(deps): update & regenerate parser"
+        body: ${{steps.outputs.versions.pr_body}}
+        branch: ${{inputs.pr-branch}}
+        delete-branch: true


### PR DESCRIPTION
This allows us to add optional parts to the workflows like cloning and parsing examples (soon™). The packaging workflows will remain as such since they shouldn't need optional parts (and the pypi one cannot be converted to an action).

This will, of course, increase the boilerplate in each workflow but we have the template to help with that.

These actions are too niche to have their own repos but we could create an `actions` repo and keep them there (just to get rid of the `.github/` part when using them). Non-niche actions (i.e. fuzz) may also be added to it as sumbodules.